### PR TITLE
Fix record download history

### DIFF
--- a/src/Http/Controllers/DownloadController.php
+++ b/src/Http/Controllers/DownloadController.php
@@ -32,14 +32,14 @@ class DownloadController extends Controller
 
         $product->toAugmentedArray()['downloadable_asset']->value()
             ->each(function (Asset $asset) use ($request, $order, $item, $product, &$zip) {
-                if (isset($item['download_history']) && $product->has('download_limit')) {
-                    if (collect($item['download_history'])->count() >= $product->get('download_limit')) {
+                if (isset($item['metadata']['download_history']) && $product->has('download_limit')) {
+                    if (collect($item['metadata']['download_history'])->count() >= $product->get('download_limit')) {
                         abort(405, "You've reached the download limit for this product.");
                     }
                 }
 
                 $order->updateLineItem($item['id'], [
-                    'metadata' => array_merge([
+                    'metadata' => array_merge(Arr::get($item, 'metadata', []), [
                         'download_history' => array_merge(
                             [
                                 [
@@ -49,7 +49,7 @@ class DownloadController extends Controller
                             ],
                             isset($item['metadata']['download_history']) ? $item['metadata']['download_history'] : [],
                         ),
-                    ], Arr::get($item, 'metadata', [])),
+                    ]),
                 ]);
 
                 $zip->addFile($asset->resolvedPath(), "{$product->slug()}/{$asset->basename()}");


### PR DESCRIPTION
## Description

This PR fixes the problem of the `download_history` not being recorded in any order's front matter. Done by switching the orders of how the arrays are merged.

Also fixed the retrieval of said key from the `$item` variable. Added a `metadata` key before `download_history` since it is structured that way in the front matter.

## Related Issues

Closes #102 

