### PR TITLE
Product Variants support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Once installed, you'll see a `Digital Product` tab appear on the publish form fo
 
 In each of your digital products, you should enable the `Is Digital Product?` toggle and add the downloadable assets. These are the assets the customer will be able to access once they have purchased your product.
 
+#### Product Variants
+
+As of v3.1.0, the Digital Products addon supports adding different 'downloadable assets' per variant. So, instead of specifying the 'Download Limit' and 'Downloadable Assets' in the `Digital Product` tab, you'll specify them on each of your variants.
+
 ### Overriding the licence key generation logic
 
 By default, we create a serial license key which you can give to your customers. However, you may want to customise where the code comes from or maybe you want to send it away to a third party service.

--- a/src/Http/Controllers/DownloadController.php
+++ b/src/Http/Controllers/DownloadController.php
@@ -3,9 +3,11 @@
 namespace DoubleThreeDigital\DigitalProducts\Http\Controllers;
 
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Statamic\Assets\Asset;
+use Statamic\Facades\AssetContainer;
 use ZipArchive;
 
 class DownloadController extends Controller
@@ -14,42 +16,90 @@ class DownloadController extends Controller
     {
         $order = Order::find($request->order_id);
         $item = $order->lineItems()->firstWhere('id', $request->item_id);
-        $product = $item->product();
 
-        if (! $item->metadata()->has('license_key') || $item->metadata()->get('license_key') !== $request->license_key) {
+        if (! $item->metadata()->has('license_key') || $item->metadata()->get('license_key') !== $request->get('license_key')) {
             abort(401);
         }
 
-        if (! $product->has('downloadable_asset')) {
-            throw new \Exception("Product [{$product->id()}] does not have any digital downloadable assets.");
-        }
+        $product = $item->product();
 
         $zip = new ZipArchive;
         $zip->open(storage_path("{$order->id()}__{$item->id()}__{$product->id()}.zip"), ZipArchive::CREATE | ZipArchive::OVERWRITE);
 
-        $product->toAugmentedArray()['downloadable_asset']->value()->get()
-            ->each(function (Asset $asset) use ($request, $order, $item, $product, &$zip) {
-                if (config('sc-digital-products.download_history')) {
-                    if ($item->metadata()->has('download_history') && $product->has('download_limit')) {
-                        if (collect($item->datadata()->get('download_history'))->count() >= $product->get('download_limit')) {
-                            abort(405, "You've reached the download limit for this product.");
+        if ($product->purchasableType() === ProductType::PRODUCT()) {
+            if (! $product->has('downloadable_asset')) {
+                throw new \Exception("Product [{$product->id()}] does not have any digital downloadable assets.");
+            }
+
+            $product->toAugmentedArray()['downloadable_asset']->value()->get()
+                ->each(function (Asset $asset) use ($request, $order, $item, $product, &$zip) {
+                    if (config('sc-digital-products.download_history')) {
+                        if ($item->metadata()->has('download_history') && $product->has('download_limit')) {
+                            if (collect($item->metadata()->get('download_history'))->count() >= $product->get('download_limit')) {
+                                abort(405, "You've reached the download limit for this product.");
+                            }
                         }
+
+                        $order->updateLineItem($item->id(), [
+                            'metadata' => array_merge($item->metadata()->toArray(), [
+                                'download_history' => array_merge([
+                                    [
+                                        'timestamp'  => now()->timestamp,
+                                        'ip_address' => $request->ip(),
+                                    ],
+                                ], $item->metadata()->get('download_history', [])),
+                            ]),
+                        ]);
                     }
 
-                    $order->updateLineItem($item->id(), [
-                        'metadata' => array_merge($item->metadata()->toArray(), [
-                            'download_history' => array_merge([
-                                [
-                                    'timestamp'  => now()->timestamp,
-                                    'ip_address' => $request->ip(),
-                                ],
-                            ], $item->metadata()->get('download_history', [])),
-                        ]),
-                    ]);
-                }
+                    $zip->addFile($asset->resolvedPath(), "{$product->get('slug')}/{$asset->basename()}");
+                });
+        }
 
-                $zip->addFile($asset->resolvedPath(), "{$product->get('slug')}/{$asset->basename()}");
-            });
+        if ($product->purchasableType() === ProductType::VARIANT()) {
+            $productVariant = $product->variant($item->variant()['variant']);
+
+            if (! $productVariant->has('downloadable_asset')) {
+                throw new \Exception("Product [{$product->id()}] does not have any digital downloadable assets.");
+            }
+
+            $productVariantsField = $product->resource()->blueprint()->field('product_variants');
+
+            $downloadableAssetField = collect($productVariantsField->get('option_fields'))
+                ->where('handle', 'downloadable_asset')
+                ->first();
+
+            collect($productVariant->get('downloadable_asset'))
+                ->map(function ($assetPath) use ($downloadableAssetField) {
+                    $assetContainer = isset($downloadableAssetField['field']['container'])
+                        ? AssetContainer::findByHandle($downloadableAssetField['field']['container'])
+                        : AssetContainer::all()->first();
+
+                    return $assetContainer->asset($assetPath);
+                })
+                ->each(function (Asset $asset) use ($request, $order, $item, $product, $productVariant, &$zip) {
+                    if (config('sc-digital-products.download_history')) {
+                        if ($item->metadata()->has('download_history') && $productVariant->has('download_limit') && $product->get('download_limit') !== null) {
+                            if (collect($item->metadata()->get('download_history'))->count() >= $productVariant->get('download_limit')) {
+                                abort(405, "You've reached the download limit for this product.");
+                            }
+                        }
+
+                        $order->updateLineItem($item->id(), [
+                            'metadata' => array_merge($item->metadata()->toArray(), [
+                                'download_history' => array_merge([
+                                    [
+                                        'timestamp'  => now()->timestamp,
+                                        'ip_address' => $request->ip(),
+                                    ],
+                                ], $item->metadata()->get('download_history', [])),
+                            ]),
+                        ]);
+                    }
+
+                    $zip->addFile($asset->resolvedPath(), "{$productVariant->key()}/{$asset->basename()}");
+                });
+        }
 
         $zip->close();
 


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request implements support for 'Product Variants' to have their own downloadable assets. Previously, you could only add variants for the whole product. 

## To Do

* [X] Updated the code which adds fields to the product blueprint
* [X] Updated the `DownloadController` to get downloadables from variant
* [X] Updated the documentation
