### PR TITLE
Refactor order completion check in VerificationController

### DIFF
--- a/src/Http/Controllers/VerificationController.php
+++ b/src/Http/Controllers/VerificationController.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\DigitalProducts\Http\Controllers;
 
 use DoubleThreeDigital\DigitalProducts\Http\Requests\VerificationRequest;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use Illuminate\Routing\Controller;
 
 class VerificationController extends Controller
@@ -12,7 +13,10 @@ class VerificationController extends Controller
     {
         $orders = collect(Order::all())
             ->filter(function ($order) {
-                return $order->get('is_paid') === true;
+                return in_array($order->get('order_status'), [
+                    OrderStatus::Placed->value,
+                    OrderStatus::Dispatched->value,
+                ]);
             })
             ->map(function ($order) use ($request) {
                 foreach ($order->get('items') as $item) {

--- a/tests/Http/VerificationControllerTest.php
+++ b/tests/Http/VerificationControllerTest.php
@@ -18,7 +18,8 @@ class VerificationControllerTest extends TestCase
 
         Entry::make()
             ->collection('orders')
-            ->set('is_paid', true)
+            ->set('order_status', 'placed')
+            ->set('payment_status', 'paid')
             ->set('items', [
                 [
                     'metadata' => [


### PR DESCRIPTION
This pull request refactors a check in the `VerificationController` where it was checking the value of the `is_paid` field, which is no longer used in Simple Commerce since v5.x.

The check now checks the "order status" - if it's in a Placed/Dispatched state, then it'll return successful.