### PR TITLE
[5.x] Fix fields being added to blueprint

### DIFF
--- a/src/Listeners/AddFieldsToProductBlueprint.php
+++ b/src/Listeners/AddFieldsToProductBlueprint.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\DigitalProducts\Listeners;
 
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Statamic\Events\EntryBlueprintFound;
+use Statamic\Facades\AssetContainer;
 
 class AddFieldsToProductBlueprint
 {
@@ -71,6 +72,7 @@ class AddFieldsToProductBlueprint
                 'type' => 'assets',
                 'mode' => 'grid',
                 'display' => 'Downloadable Asset',
+                'container' => AssetContainer::all()->first()->handle(),
                 'if' => [
                     'is_digital_product' => 'equals true',
                 ],

--- a/src/Listeners/AddFieldsToProductBlueprint.php
+++ b/src/Listeners/AddFieldsToProductBlueprint.php
@@ -76,7 +76,7 @@ class AddFieldsToProductBlueprint
                 'type' => 'assets',
                 'mode' => 'grid',
                 'display' => 'Downloadable Asset',
-                'container' => AssetContainer::all()->first()->handle(),
+                'container' => AssetContainer::all()->first()?->handle(),
                 'if' => [
                     'is_digital_product' => 'equals true',
                 ],

--- a/src/Listeners/AddFieldsToProductBlueprint.php
+++ b/src/Listeners/AddFieldsToProductBlueprint.php
@@ -63,6 +63,9 @@ class AddFieldsToProductBlueprint
                 'type' => 'integer',
                 'display' => 'Download Limit',
                 'instructions' => "If you'd like to limit the amount if times this product can be downloaded, set it here. Keep it blank if you'd like it to be unlimited.",
+                'if' => [
+                    'is_digital_product' => 'equals true',
+                ],
             ],
             'downloadable_asset' => [
                 'type' => 'assets',

--- a/src/Listeners/AddFieldsToProductBlueprint.php
+++ b/src/Listeners/AddFieldsToProductBlueprint.php
@@ -50,9 +50,11 @@ class AddFieldsToProductBlueprint
             return $event->blueprint;
         }
 
-        collect($this->getDigitalProductFields())->each(function ($value, $key) use (&$event) {
-            $event->blueprint->ensureField($key, $value, 'Digital Product');
-        });
+        collect($this->getDigitalProductFields())
+            ->reject(fn ($value, $key) => $event->blueprint->hasField($key))
+            ->each(function ($value, $key) use (&$event) {
+                $event->blueprint->ensureField($key, $value, 'Digital Product');
+            });
 
         return $event->blueprint;
     }

--- a/src/Listeners/AddFieldsToProductBlueprint.php
+++ b/src/Listeners/AddFieldsToProductBlueprint.php
@@ -18,10 +18,12 @@ class AddFieldsToProductBlueprint
             return $event->blueprint;
         }
 
-        $event->blueprint->ensureField('is_digital_product', [
-            'type' => 'toggle',
-            'display' => 'Is Digital Product?',
-        ], 'Digital Product');
+        if (! $event->blueprint->hasField('is_digital_product')) {
+            $event->blueprint->ensureField('is_digital_product', [
+                'type' => 'toggle',
+                'display' => 'Is Digital Product?',
+            ], 'Digital Product');
+        }
 
         if ($event->blueprint->hasField('product_variants')) {
             $productVariantsField = $event->blueprint->field('product_variants');


### PR DESCRIPTION
This pull request fixes a couple of issues around the fields this addon injects into product blueprints.

* The "Download Limit" field will now only show if "Is Digital Product" is true.
* To avoid an error in your product entries, the addon will use the first asset container it can find for the "Downloadable Asset" field.
* Now, the addon will only add fields to the product blueprint if those fields don't already exist (meaning custom configuration settings on those fields will no longer be reset). 

Fixes #129