### PR TITLE
Fix duplicate digital product fields being added to variant options

### DIFF
--- a/src/Listeners/AddFieldsToProductBlueprint.php
+++ b/src/Listeners/AddFieldsToProductBlueprint.php
@@ -28,35 +28,43 @@ class AddFieldsToProductBlueprint
         if ($event->blueprint->hasField('product_variants')) {
             $productVariantsField = $event->blueprint->field('product_variants');
 
-            $event->blueprint->ensureFieldHasConfig(
-                'product_variants',
-                array_merge(
-                    $productVariantsField->toArray(),
-                    [
-                        'option_fields' => array_merge(
-                            $productVariantsField->get('option_fields', []),
-                            collect($this->getDigitalProductFields())
-                                ->map(function ($value, $key) {
-                                    return [
-                                        'handle' => $key,
-                                        'field' => $value,
-                                    ];
-                                })
-                                ->values()
-                                ->toArray()
-                        ),
-                    ]
-                )
-            );
+            $hasDigitalProductFields = collect($productVariantsField->config()['option_fields'])
+                ->filter(function ($value, $key) {
+                    return $value['handle'] === 'download_limit' || $value['handle'] === 'downloadable_asset';
+                })
+                ->count() > 0;
+
+            if (! $hasDigitalProductFields) {
+                $event->blueprint->ensureFieldHasConfig(
+                    'product_variants',
+                    array_merge(
+                        $productVariantsField->toArray(),
+                        [
+                            'option_fields' => array_merge(
+                                $productVariantsField->get('option_fields', []),
+                                collect($this->getDigitalProductFields())
+                                    ->map(function ($value, $key) {
+                                        return [
+                                            'handle' => $key,
+                                            'field' => $value,
+                                        ];
+                                    })
+                                    ->values()
+                                    ->toArray()
+                            ),
+                        ]
+                    )
+                );
+            }
 
             return $event->blueprint;
+        } else {
+            collect($this->getDigitalProductFields())
+                ->reject(fn ($value, $key) => $event->blueprint->hasField($key))
+                ->each(function ($value, $key) use (&$event) {
+                    $event->blueprint->ensureField($key, $value, 'Digital Product');
+                });
         }
-
-        collect($this->getDigitalProductFields())
-            ->reject(fn ($value, $key) => $event->blueprint->hasField($key))
-            ->each(function ($value, $key) use (&$event) {
-                $event->blueprint->ensureField($key, $value, 'Digital Product');
-            });
 
         return $event->blueprint;
     }


### PR DESCRIPTION
This pull request fixes an issue on variant products where duplicate digital product fields would be added whenever the blueprint was viewed.

Fixes #131.