### PR TITLE
Fix `AddFieldsToProductBlueprint` when no variant option fields are configured

### DIFF
--- a/src/Listeners/AddFieldsToProductBlueprint.php
+++ b/src/Listeners/AddFieldsToProductBlueprint.php
@@ -28,7 +28,7 @@ class AddFieldsToProductBlueprint
         if ($event->blueprint->hasField('product_variants')) {
             $productVariantsField = $event->blueprint->field('product_variants');
 
-            $hasDigitalProductFields = collect($productVariantsField->config()['option_fields'])
+            $hasDigitalProductFields = collect($productVariantsField->config()['option_fields'] ?? [])
                 ->filter(function ($value, $key) {
                     return $value['handle'] === 'download_limit' || $value['handle'] === 'downloadable_asset';
                 })


### PR DESCRIPTION
This pull request fixes an error from the `AddFieldsToProductBlueprint` listener that'd occur when you had a `product_variants` field present on a Product blueprint without any option fields configured.

Fixes #133.