### PR TITLE
[5.x] Fix "Is Digital Product" toggle field not working with product variants

### DIFF
--- a/src/Listeners/AddFieldsToProductBlueprint.php
+++ b/src/Listeners/AddFieldsToProductBlueprint.php
@@ -18,13 +18,6 @@ class AddFieldsToProductBlueprint
             return $event->blueprint;
         }
 
-        if (! $event->blueprint->hasField('is_digital_product')) {
-            $event->blueprint->ensureField('is_digital_product', [
-                'type' => 'toggle',
-                'display' => 'Is Digital Product?',
-            ], 'Digital Product');
-        }
-
         if ($event->blueprint->hasField('product_variants')) {
             $productVariantsField = $event->blueprint->field('product_variants');
 
@@ -62,7 +55,7 @@ class AddFieldsToProductBlueprint
             collect($this->getDigitalProductFields())
                 ->reject(fn ($value, $key) => $event->blueprint->hasField($key))
                 ->each(function ($value, $key) use (&$event) {
-                    $event->blueprint->ensureField($key, $value, 'Digital Product');
+                    $event->blueprint->ensureField($key, $value, __('Digital Product'));
                 });
         }
 
@@ -72,10 +65,14 @@ class AddFieldsToProductBlueprint
     protected function getDigitalProductFields()
     {
         return [
+            'is_digital_product' => [
+                'type' => 'toggle',
+                'display' => __('Is Digital Product?'),
+            ],
             'download_limit' => [
                 'type' => 'integer',
-                'display' => 'Download Limit',
-                'instructions' => "If you'd like to limit the amount if times this product can be downloaded, set it here. Keep it blank if you'd like it to be unlimited.",
+                'display' => __('Download Limit'),
+                'instructions' => __("If you'd like to limit the amount if times this product can be downloaded, set it here. Keep it blank if you'd like it to be unlimited."),
                 'if' => [
                     'is_digital_product' => 'equals true',
                 ],
@@ -83,7 +80,7 @@ class AddFieldsToProductBlueprint
             'downloadable_asset' => [
                 'type' => 'assets',
                 'mode' => 'grid',
-                'display' => 'Downloadable Asset',
+                'display' => __('Downloadable Asset'),
                 'container' => AssetContainer::all()->first()?->handle(),
                 'if' => [
                     'is_digital_product' => 'equals true',

--- a/src/Listeners/ProcessCheckout.php
+++ b/src/Listeners/ProcessCheckout.php
@@ -7,7 +7,6 @@ use DoubleThreeDigital\DigitalProducts\Facades\LicenseKey;
 use DoubleThreeDigital\SimpleCommerce\Events\OrderStatusUpdated;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductVariant;
 use Illuminate\Support\Facades\URL;
 
 class ProcessCheckout

--- a/src/Listeners/ProcessCheckout.php
+++ b/src/Listeners/ProcessCheckout.php
@@ -6,6 +6,8 @@ use DoubleThreeDigital\DigitalProducts\Events\DigitalDownloadReady;
 use DoubleThreeDigital\DigitalProducts\Facades\LicenseKey;
 use DoubleThreeDigital\SimpleCommerce\Events\OrderStatusUpdated;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductVariant;
 use Illuminate\Support\Facades\URL;
 
 class ProcessCheckout
@@ -21,9 +23,17 @@ class ProcessCheckout
             ->filter(function ($lineItem) {
                 $product = $lineItem->product();
 
-                return $product->has('is_digital_product') ?
-                    $product->get('is_digital_product') :
-                    false;
+                if ($product->purchasableType() === ProductType::Variant) {
+                    $productVariant = $product->variant($lineItem->variant());
+
+                    return $productVariant->has('is_digital_product')
+                        ? $productVariant->get('is_digital_product')
+                        : false;
+                }
+
+                return $product->has('is_digital_product')
+                    ? $product->get('is_digital_product')
+                    : false;
             })
             ->each(function ($lineItem) use ($event) {
                 $event->order->updateLineItem($lineItem->id(), [

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,6 +27,10 @@ class ServiceProvider extends AddonServiceProvider
         'actions' => __DIR__.'/../routes/actions.php',
     ];
 
+    protected $updateScripts = [
+        UpdateScripts\FixDigitalProductToggleForVariantProducts::class,
+    ];
+
     public function boot()
     {
         parent::boot();

--- a/src/UpdateScripts/FixDigitalProductToggleForVariantProducts.php
+++ b/src/UpdateScripts/FixDigitalProductToggleForVariantProducts.php
@@ -25,21 +25,21 @@ class FixDigitalProductToggleForVariantProducts extends UpdateScript
                     ->merge([
                         'is_digital_product' => null,
                         'product_variants' => [
-                        'variants' => $productVariants['variants'],
-                        'options' => collect($productVariants['options'])
-                            ->map(function ($option) {
-                                $option['is_digital_product'] = true;
+                            'variants' => $productVariants['variants'],
+                            'options' => collect($productVariants['options'])
+                                ->map(function ($option) {
+                                    $option['is_digital_product'] = true;
 
-                                return $option;
-                            })
-                            ->values()
-                            ->toArray(),
+                                    return $option;
+                                })
+                                ->values()
+                                ->toArray(),
                         ],
                     ])
                     ->save();
             });
 
-        Blueprint::in("collections.products")
+        Blueprint::in('collections.products')
             ->filter(fn ($blueprint) => $blueprint->hasField('is_digital_product'))
             ->filter(fn ($blueprint) => $blueprint->hasField('product_variants'))
             ->each(function ($blueprint) {

--- a/src/UpdateScripts/FixDigitalProductToggleForVariantProducts.php
+++ b/src/UpdateScripts/FixDigitalProductToggleForVariantProducts.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\DigitalProducts\UpdateScripts;
 
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use Statamic\Facades\Blueprint;
 use Statamic\UpdateScripts\UpdateScript;
 
 class FixDigitalProductToggleForVariantProducts extends UpdateScript
@@ -36,6 +37,13 @@ class FixDigitalProductToggleForVariantProducts extends UpdateScript
                         ],
                     ])
                     ->save();
+            });
+
+        Blueprint::in("collections.products")
+            ->filter(fn ($blueprint) => $blueprint->hasField('is_digital_product'))
+            ->filter(fn ($blueprint) => $blueprint->hasField('product_variants'))
+            ->each(function ($blueprint) {
+                $blueprint->removeTab('Digital Product')->save();
             });
     }
 }

--- a/src/UpdateScripts/FixDigitalProductToggleForVariantProducts.php
+++ b/src/UpdateScripts/FixDigitalProductToggleForVariantProducts.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DoubleThreeDigital\DigitalProducts\UpdateScripts;
+
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use Statamic\UpdateScripts\UpdateScript;
+
+class FixDigitalProductToggleForVariantProducts extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('5.1.0');
+    }
+
+    public function update()
+    {
+        collect(Product::all())
+            ->filter(fn ($entry) => $entry->get('is_digital_product') === true)
+            ->filter(fn ($entry) => $entry->has('product_variants'))
+            ->each(function ($entry) {
+                $productVariants = $entry->get('product_variants');
+
+                $entry
+                    ->merge([
+                        'is_digital_product' => null,
+                        'product_variants' => [
+                        'variants' => $productVariants['variants'],
+                        'options' => collect($productVariants['options'])
+                            ->map(function ($option) {
+                                $option['is_digital_product'] = true;
+
+                                return $option;
+                            })
+                            ->values()
+                            ->toArray(),
+                        ],
+                    ])
+                    ->save();
+            });
+    }
+}

--- a/tests/Listeners/AddFieldsToProductBlueprintTest.php
+++ b/tests/Listeners/AddFieldsToProductBlueprintTest.php
@@ -27,6 +27,41 @@ class AddFieldsToProductBlueprintTest extends TestCase
     }
 
     /** @test */
+    public function fields_can_be_addded_to_product_blueprint_with_product_variants()
+    {
+        $blueprint = Blueprint::make('product')
+            ->setNamespace('collections.products')
+            ->setContents([
+                'tabs' => ['main' => ['sections' => [
+                    ['fields' => [
+                        [
+                            'handle' => 'product_variants',
+                            'field' => ['type' => 'product_variants'],
+                        ],
+                    ]]
+                ]]]
+            ])
+            ->save();
+
+        $event = new EntryBlueprintFound($blueprint);
+
+        $handle = (new AddFieldsToProductBlueprint())->handle($event);
+
+        $this->assertFalse($handle->hasField('is_digital_product'));
+        $this->assertFalse($handle->hasField('download_limit'));
+        $this->assertFalse($handle->hasField('downloadable_asset'));
+        $this->assertFalse($handle->hasTab('Digital Product'));
+        $this->assertTrue($handle->hasField('product_variants'));
+
+        $optionFields = collect($handle->field('product_variants')->config()['option_fields']);
+
+        $this->assertCount(3, $optionFields);
+        $this->assertTrue($optionFields->where('handle', 'is_digital_product')->count() > 0);
+        $this->assertTrue($optionFields->where('handle', 'download_limit')->count() > 0);
+        $this->assertTrue($optionFields->where('handle', 'downloadable_asset')->count() > 0);
+    }
+
+    /** @test */
     public function fields_are_not_added_to_orders_blueprint()
     {
         $blueprint = Blueprint::make('orders')

--- a/tests/Listeners/AddFieldsToProductBlueprintTest.php
+++ b/tests/Listeners/AddFieldsToProductBlueprintTest.php
@@ -38,8 +38,8 @@ class AddFieldsToProductBlueprintTest extends TestCase
                             'handle' => 'product_variants',
                             'field' => ['type' => 'product_variants'],
                         ],
-                    ]]
-                ]]]
+                    ]],
+                ]]],
             ])
             ->save();
 

--- a/tests/Listeners/ProcessCheckoutTest.php
+++ b/tests/Listeners/ProcessCheckoutTest.php
@@ -88,4 +88,74 @@ class ProcessCheckoutTest extends TestCase
             DigitalDownloadsNotification::class,
         );
     }
+
+    /** @test */
+    public function can_process_checkout_with_variant_product()
+    {
+        Notification::fake();
+
+        Config::set('simple-commerce.notifications', [
+            'digital_download_ready' => [
+                DigitalDownloadsNotification::class => [
+                    'to' => 'customer',
+                ],
+            ],
+        ]);
+
+        $product = Product::make()
+            ->price(1200)
+            ->productVariants([
+                'variants' => [
+                    ['name' => 'Colours', 'values' => ['Red']],
+                    ['name' => 'Sizes', 'values' => ['Small']],
+                ],
+                'options' => [
+                    ['key' => 'Red_Small', 'variant' => 'Red Small', 'price' => 1200, 'is_digital_product' => true],
+                ],
+            ]);
+
+        $product->save();
+
+        $customer = Customer::make()
+            ->email('duncan@example.com')
+            ->merge([
+                'name' => 'Duncan',
+            ]);
+
+        $customer->save();
+
+        $order = Order::make()
+            ->lineItems([
+                [
+                    'id' => Stache::generateId(),
+                    'product' => $product->id(),
+                    'quantity' => 1,
+                    'variant' => 'Red_Small',
+                    'total' => 1200,
+                ],
+            ])
+            ->customer($customer->id());
+
+        $order->save();
+
+        $order->updateOrderStatus(OrderStatus::Placed);
+        $order->updatePaymentStatus(PaymentStatus::Paid);
+
+        $order->save();
+
+        $order = $order->fresh();
+
+        // Asset metadata is saved
+        $lineItem = $order->lineItems()->first();
+
+        $this->assertTrue($lineItem->metadata()->has('license_key'));
+        $this->assertTrue($lineItem->metadata()->has('download_url'));
+        $this->assertTrue($lineItem->metadata()->has('download_history'));
+
+        // Assert notification has been sent
+        Notification::assertSentTo(
+            new AnonymousNotifiable,
+            DigitalDownloadsNotification::class,
+        );
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue when using the Digital Products addon in product variants.

Previously, the "Is Digital Product" field was ensured to the "Digital Products" tab in the product publish form and we were able to use that field with field conditions on the "Download Limit" & "Downloadable Asset" fields.

However, since this was implemented, it looks like field conditions on product variants are scoped to _just_ that variant option (which makes sense), however, it means that the "Is Digital Product" toggle needs to move to each of the product variants.

Fixes #135.

## To Do

* [x] Provide an upgrade script for existing products
* [x] Ensure everything that checks `is_digital_product` on the root of the product also checks the individual variant options. 
* [x] Add test to ensure the `is_digital_product` field gets ensured differently