### PR TITLE
[5.x] Fix variant lookup in `ProcessCheckout` listener

### DIFF
--- a/src/Listeners/ProcessCheckout.php
+++ b/src/Listeners/ProcessCheckout.php
@@ -23,7 +23,7 @@ class ProcessCheckout
                 $product = $lineItem->product();
 
                 if ($product->purchasableType() === ProductType::Variant) {
-                    $productVariant = $product->variant($lineItem->variant());
+                    $productVariant = $product->variant($lineItem->variant()['variant'] ?? $lineItem->variant());
 
                     return $productVariant->has('is_digital_product')
                         ? $productVariant->get('is_digital_product')

--- a/tests/Listeners/ProcessCheckoutTest.php
+++ b/tests/Listeners/ProcessCheckoutTest.php
@@ -130,7 +130,10 @@ class ProcessCheckoutTest extends TestCase
                     'id' => Stache::generateId(),
                     'product' => $product->id(),
                     'quantity' => 1,
-                    'variant' => 'Red_Small',
+                    'variant' => [
+                        'variant' => 'Red_Small',
+                        'product' => $product->id(),
+                    ],
                     'total' => 1200,
                 ],
             ])


### PR DESCRIPTION
This pull request fixes an issue with the `ProcessCheckout` listener where it would fail if the `variant` on the `LineItem` was an array (which it often is, strings are legacy). 

This PR changes the code so it'll accept `variant` as both an array and a string. I've also adjusted the related test.

Fixes #138.